### PR TITLE
Update FUNDING.yml

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,1 +1,2 @@
-custom: https://numfocus.salsalabs.org/donate-to-conda-forge/index.html
+github: numfocus
+custom: https://numfocus.org/donate-to-conda-forge


### PR DESCRIPTION
add NumFOCUS github sponsors button (recurring donations only)

This feature launched today at GitHub Universe!

Also pointed the custom link to the donation form hosted by numfocus.org in case that provides more peace of mind for potential donors.