### PR TITLE
specify usage of personal fork in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@ Thank you for pull request.
 Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
 -->
 Checklist
-* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
+* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
 * [ ] Bumped the build number (if the version is unchanged)
 * [ ] Reset the build number to `0` (if the version changed)
 * [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)


### PR DESCRIPTION
Currently only personal forks allow the "allow maintainer changes"
functionality in a PR.
refs https://github.com/conda-forge/webservices-dispatch-action/issues/4
